### PR TITLE
Ensure Type Accuracy in updateSignal Method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gentleman-agnostic-signals",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "",

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,7 +1,7 @@
 import { SignalsManager } from "./signals_manager";
 
 let signalsManager: SignalsManager<any>;
-export type SignalsState<T = {}> = { [K in keyof T]: any };
+export type SignalsState<T = {}> = { [K in keyof T]: T[K] };
 
 export function initSignalsManager<T extends SignalsState<T>>(
   defaultState: T,

--- a/src/signals_manager.ts
+++ b/src/signals_manager.ts
@@ -1,6 +1,6 @@
 import { Signal, SignalsAdapter, SignalsDomain } from "./domain";
 
-export class SignalsManager<T extends { [K in keyof T]: any }> {
+export class SignalsManager<T extends { [K in keyof T]: T[K] }> {
   signalsCollection = new Map<keyof T, Signal<T[keyof T]>>();
   signalsAdapter: SignalsAdapter<T>;
 
@@ -27,7 +27,7 @@ export class SignalsManager<T extends { [K in keyof T]: any }> {
     return foundSignal;
   }
 
-  updateSignal(key: keyof T, payload: T[keyof T]) {
+  updateSignal<K extends keyof T>(key: K, payload: T[K]) {
     const foundSignal = this.getSignal(key);
 
     this.signalsAdapter.updateSignal(foundSignal, payload);


### PR DESCRIPTION
Hello Gentleman!
Here is my contribuiton to the project!.
Fixed a type glitch in `updateSignal` – now it knows its numbers from its strings and so on depends on the state type 🌟🌟

Before:
![image](https://github.com/Gentleman-Programming/gentleman-agnostic-signals/assets/102027741/153a6389-08a6-42df-86fb-618ccdbb5127)

After: 
![image](https://github.com/Gentleman-Programming/gentleman-agnostic-signals/assets/102027741/1d8a78ac-02d3-405f-9f35-81ea66015749)
